### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, rockylinux-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Available variables are listed below (located in `defaults/main.yml`):
 ```yaml
 helm_app: helm
 helm_version: 3.8.0
-helm_osarch: amd64
-helm_dl_url: https://get.{{ helm_app }}.sh/{{ helm_app }}-v{{ helm_version }}-linux-{{ helm_osarch }}.tar.gz
+helm_os: linux
+helm_arch: amd64
+helm_dl_url: https://get.{{ helm_app }}.sh/{{ helm_app }}-v{{ helm_version }}-{{ helm_os }}-{{ helm_arch }}.tar.gz
 helm_bin_path: /usr/local/bin
 helm_file_owner: root
 helm_file_group: root
+helm_file_mode: '0755'
 ```
 
 ### Variables table:
@@ -30,11 +32,13 @@ Variable        | Description
 --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------
 helm_app        | Defines the app to install i.e. **helm**
 helm_version    | Defined to dynamically fetch the desired version to install. Defaults to: **3.8.0**
-helm_osarch     | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture.
+helm_os         | Defines os type. Used for obtaining the correct type of binaries based on OS type. Defaults to: **linux**
+helm_arch       | Defines os architecture. Used to set the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
 helm_dl_url     | Defines URL to download the helm binary from.
 helm_bin_path   | Defined to dynamically set the appropriate path to store helm binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
 helm_file_owner | Owner for the binary file of helm.
 helm_file_group | Group for the binary file of helm.
+helm_file_mode  | Mode for the binary file of helm.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,10 @@
 
 helm_app: helm
 helm_version: 3.8.0
-helm_osarch: amd64
-helm_dl_url: https://get.{{ helm_app }}.sh/{{ helm_app }}-v{{ helm_version }}-linux-{{ helm_osarch }}.tar.gz
+helm_os: linux
+helm_arch: amd64
+helm_dl_url: https://get.{{ helm_app }}.sh/{{ helm_app }}-v{{ helm_version }}-{{ helm_os }}-{{ helm_arch }}.tar.gz
 helm_bin_path: /usr/local/bin
 helm_file_owner: root
 helm_file_group: root
+helm_file_mode: '0755'

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,3 +3,5 @@
   hosts: all
   roles:
     - role: darkwizard242.helm
+  vars:
+    ansible_python_interpreter: /usr/bin/python3

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -11,3 +11,4 @@
     remote_src: yes
     owner: "{{ helm_file_owner }}"
     group: "{{ helm_file_group }}"
+    mode: "{{ helm_file_mode }}"

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -7,7 +7,7 @@
     dest: "{{ helm_bin_path }}"
     extra_opts:
       - --strip-components=1
-      - "linux-{{ helm_osarch }}/{{ helm_app }}"
+      - "{{ helm_os }}-{{ helm_arch }}/{{ helm_app }}"
     remote_src: yes
     owner: "{{ helm_file_owner }}"
     group: "{{ helm_file_group }}"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -11,3 +11,4 @@
     remote_src: yes
     owner: "{{ helm_file_owner }}"
     group: "{{ helm_file_group }}"
+    mode: "{{ helm_file_mode }}"

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -7,7 +7,7 @@
     dest: "{{ helm_bin_path }}"
     extra_opts:
       - --strip-components=1
-      - "linux-{{ helm_osarch }}/{{ helm_app }}"
+      - "{{ helm_os }}-{{ helm_arch }}/{{ helm_app }}"
     remote_src: yes
     owner: "{{ helm_file_owner }}"
     group: "{{ helm_file_group }}"


### PR DESCRIPTION
- Seperate out OS and ARCH into seperate vars
- Setup key/value attributes for modeof binary file and update Debian/Ubuntu/EL family tasks
- Set `ansible_python_interpreter` var in molecule's converge playbook
- Utilize Rocky Linux 8 for EL 8 OS versions